### PR TITLE
Added more driver functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ fedora_install: all
 	# Copy over systemd config
 	mkdir -p $(DESTDIR)/etc/systemd/system/
 	install -v -D install_files/systemd/razer_bcd.service $(DESTDIR)/usr/lib/systemd/system/razer_bcd.service
-	ln -s /usr/lib/systemd/system/razer_bcd.service $(DESTDIR)/etc/systemd/system/razer_bcd.service
+	ln -f -s /usr/lib/systemd/system/razer_bcd.service $(DESTDIR)/etc/systemd/system/razer_bcd.service
 	
 	# Install application entries	
 	install -v -D install_files/desktop/razer_tray_applet.desktop $(DESTDIR)/usr/share/applications/razer_tray_applet.desktop


### PR DESCRIPTION
Added device file get_serial. This will query the keyboard, firefly and mamba for the devices serial number. The file is meant to be read from and not written to. Will go through the drivers and set permissions appropriately to restrict either reading or writing.

Also added a little bit to makefile so symlink is replaced.