### PR TITLE
Add in upstart user jobs for turning keyboard effects on and off.

### DIFF
--- a/scripts/misc/lockscreen.conf
+++ b/scripts/misc/lockscreen.conf
@@ -1,0 +1,10 @@
+description "Turn off keyboard lights"
+author "Brian Murray"
+
+start on started unity-panel-service-lockscreen
+
+script
+
+python -c 'import dbus; system_bus = dbus.SystemBus(); dbus_daemon_object = system_bus.get_object("org.voyagerproject.razer.daemon", "/"); dbus_driver_effect_object = dbus.Interface(dbus_daemon_object, "org.voyagerproject.razer.daemon.driver_effect"); dbus_driver_effect_object.none()'
+
+end script

--- a/scripts/misc/unlockscreen.conf
+++ b/scripts/misc/unlockscreen.conf
@@ -1,0 +1,10 @@
+description "Turn on keyboard lights"
+author "Brian Murray"
+
+start on stopped unity-panel-service-lockscreen
+
+script
+
+python -c 'import dbus; system_bus = dbus.SystemBus(); dbus_daemon_object = system_bus.get_object("org.voyagerproject.razer.daemon", "/"); dbus_driver_effect_object = dbus.Interface(dbus_daemon_object, "org.voyagerproject.razer.daemon.driver_effect"); dbus_driver_effect_object.static(0, 255, 0)'
+
+end script


### PR DESCRIPTION
I thought it would be useful to turn off the keyboard lights when I'm not using my system. To that end I've written an upstart user job (lockscreen.conf), to be place in ~/.config/upstart/, that sets the keyboard lighting effect to none when the Unity lockscreen is started. There is a corresponding job that runs when Unity lockscreen stops to set a keyboard lighting effect. I've confirmed these work on Ubuntu 16.04 and am happy to modify them for other lockscreens.