### PR TITLE
Makefiles: tolerant uninstall, eol cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,67 +17,67 @@ razer_drv_verbose:
 	make -C $(KERNELDIR) SUBDIRS=$(DRIVERDIR) modules
 
 
-librazer_chroma: 
+librazer_chroma:
 	make -C lib all
 
-librazer_chroma_clean: 
-	make -C lib clean 
+librazer_chroma_clean:
+	make -C lib clean
 
-razer_daemon: 
+razer_daemon:
 	make -C daemon all
 
-razer_daemon_clean: 
-	make -C daemon clean 
+razer_daemon_clean:
+	make -C daemon clean
 
-razer_daemon_controller: 
+razer_daemon_controller:
 	make -C daemon_controller all
 
-razer_daemon_controller_clean: 
-	make -C daemon_controller clean 
+razer_daemon_controller_clean:
+	make -C daemon_controller clean
 
-razer_examples: 
+razer_examples:
 	make -C examples all
 
-razer_examples_clean: 
-	make -C examples clean 
+razer_examples_clean:
+	make -C examples clean
 
 fedora_install: all
-    # Install the main binaries
+	# Install the main binaries
 	make -C lib               fedora_install DESTDIR=$(DESTDIR)
 	make -C daemon            fedora_install DESTDIR=$(DESTDIR)
 	make -C daemon_controller fedora_install DESTDIR=$(DESTDIR)
-	
+
 	# Install UDEV conf
 	install -v -D install_files/udev/95-razerkbd.rules $(DESTDIR)/etc/udev/rules.d/95-razerkbd.rules
-	
+
 	# Install DBUS conf
 	install -v -D install_files/dbus/org.voyagerproject.razer.daemon.conf $(DESTDIR)/etc/dbus-1/system.d/org.voyagerproject.razer.daemon.conf
-	
+
 	# Install bash helper functions
 	install -v -D install_files/share/bash_keyboard_functions.sh $(DESTDIR)/usr/share/razer_bcd/bash_keyboard_functions.sh
 	install -v -D install_files/share/systemd_helpers.sh $(DESTDIR)/usr/share/razer_bcd/systemd_helpers.sh
-	
+
 	# Copy over systemd config
 	mkdir -p $(DESTDIR)/etc/systemd/system/
 	install -v -D install_files/systemd/razer_bcd.service $(DESTDIR)/usr/lib/systemd/system/razer_bcd.service
 	ln -f -s /usr/lib/systemd/system/razer_bcd.service $(DESTDIR)/etc/systemd/system/razer_bcd.service
-	
-	# Install application entries	
+
+	# Install application entries
 	install -v -D install_files/desktop/razer_tray_applet.desktop $(DESTDIR)/usr/share/applications/razer_tray_applet.desktop
 	install -v -D install_files/desktop/razer_chroma_controller.desktop $(DESTDIR)/usr/share/applications/razer_chroma_controller.desktop
-	
+
 	# Install Python3 library
 	install -v -d gui/lib/razer $(DESTDIR)/usr/lib/python3.4/site-packages/razer
 	cp -v -r gui/lib/razer/* $(DESTDIR)/usr/lib/python3.4/site-packages/razer
-	
+
 	# Install Tray application
 	install -v -d gui/tray_applet $(DESTDIR)/usr/share/razer_tray_applet
 	cp -v -r gui/tray_applet/* $(DESTDIR)/usr/share/razer_tray_applet
-	
+
 	# Install Chroma App
 	install -v -d gui/chroma_controller $(DESTDIR)/usr/share/razer_chroma_controller
 	cp -v -r gui/chroma_controller/* $(DESTDIR)/usr/share/razer_chroma_controller
-	
+
 	# Copy razer kernel driver to src
 	install -v -D Makefile $(DESTDIR)/usr/src/razer_chroma_driver-1.0.0/Makefile
 	install -v -D install_files/dkms/dkms.conf $(DESTDIR)/usr/src/razer_chroma_driver-1.0.0/dkms.conf
@@ -86,13 +86,13 @@ fedora_install: all
 	cp -v driver/*.c $(DESTDIR)/usr/src/razer_chroma_driver-1.0.0/driver/
 	cp -v driver/*.h $(DESTDIR)/usr/src/razer_chroma_driver-1.0.0/driver/
 	rm -fv $(DESTDIR)/usr/src/razer_chroma_driver-1.0.0/driver/*.mod.c
-	
+
 	# Set up DKMS
 	/usr/lib/dkms/common.postinst razer_chroma_driver 1.0.0 /usr/share/razer_chroma_driver-dkms
 	modprobe razerkbd
 	modprobe razermouse
 
-	
+
 
 install: all
 	make -C lib install
@@ -127,24 +127,23 @@ install: all
 	ln -fs ../init.d/razer_bcd /etc/rc6.d/K02razer_bcd
 
 uninstall:
-	make -C lib uninstall
-	make -C daemon uninstall
-	rm /etc/init.d/razer_bcd
-	rm /etc/udev/rules.d/95-razerkbd.rules
-	rm /etc/rc2.d/S24razer_bcd
-	rm /etc/rc3.d/S24razer_bcd
-	rm /etc/rc4.d/S24razer_bcd
-	rm /etc/rc5.d/S24razer_bcd
-	rm /etc/rc0.d/K02razer_bcd
-	rm /etc/rc1.d/K02razer_bcd
-	rm /etc/rc6.d/K02razer_bcd
-	rm /etc/dbus-1/system.d/org.voyagerproject.razer.daemon.conf
-	rm /usr/sbin/razer_blackwidow_chroma_activate_driver.sh
+	-make -C lib uninstall
+	-make -C daemon uninstall
+	rm -f /etc/init.d/razer_bcd
+	rm -f /etc/udev/rules.d/95-razerkbd.rules
+	rm -f /etc/rc2.d/S24razer_bcd
+	rm -f /etc/rc3.d/S24razer_bcd
+	rm -f /etc/rc4.d/S24razer_bcd
+	rm -f /etc/rc5.d/S24razer_bcd
+	rm -f /etc/rc0.d/K02razer_bcd
+	rm -f /etc/rc1.d/K02razer_bcd
+	rm -f /etc/rc6.d/K02razer_bcd
+	rm -f /etc/dbus-1/system.d/org.voyagerproject.razer.daemon.conf
+	rm -f /usr/sbin/razer_blackwidow_chroma_activate_driver.sh
 
 
 clean: librazer_chroma_clean razer_daemon_clean razer_daemon_controller_clean razer_examples_clean razer_drv_clean
 
 razer_drv_clean:
 	make -C $(KERNELDIR) SUBDIRS=$(DRIVERDIR) clean > /dev/null 2>&1
-	#added redirect to remove output of a useless makefile warning
-
+	# added redirect to remove output of a useless makefile warning

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -8,7 +8,7 @@ LIBDBUS=$(shell pkg-config --libs dbus-1 > /dev/null 2>&1 && echo 0)
 LIBFFTW3=$(shell pkg-config --libs fftw3 > /dev/null 2>&1 && echo 0)
 
 ifeq ($(LIBDBUS), 0)
-	LIBS+= `pkg-config --libs dbus-1` 
+	LIBS+= `pkg-config --libs dbus-1`
 	CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 	DEBUG_CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 endif
@@ -35,13 +35,13 @@ all: daemon_shared daemon_static daemon_debug daemon_fx
 daemon_debug: $(RAZER_CHROMA_DAEMON_DEBUG_OBJ)
 	@echo "\n::\033[32m COMPILING razer_bcd daemon [DEBUG]\033[0m"
 	@echo "======================================"
-	$(CC) -rdynamic $(RAZER_CHROMA_DAEMON_DEBUG_OBJ) ../lib/librazer_chroma.da $(LIBS) -o razer_bcd_debug_static 
-	$(CC) -L../lib -rdynamic $(RAZER_CHROMA_DAEMON_DEBUG_OBJ) -lrazer_chroma_debug $(LIBS) -o razer_bcd_debug_shared 
+	$(CC) -rdynamic $(RAZER_CHROMA_DAEMON_DEBUG_OBJ) ../lib/librazer_chroma.da $(LIBS) -o razer_bcd_debug_static
+	$(CC) -L../lib -rdynamic $(RAZER_CHROMA_DAEMON_DEBUG_OBJ) -lrazer_chroma_debug $(LIBS) -o razer_bcd_debug_shared
 
 daemon_static: $(RAZER_CHROMA_DAEMON_OBJ)
 	@echo "\n::\033[32m COMPILING razer_bcd daemon\033[0m"
 	@echo "=============================="
-	$(CC) -rdynamic $(RAZER_CHROMA_DAEMON_OBJ) ../lib/librazer_chroma.a $(LIBS) -o razer_bcd_static 
+	$(CC) -rdynamic $(RAZER_CHROMA_DAEMON_OBJ) ../lib/librazer_chroma.a $(LIBS) -o razer_bcd_static
 	@strip razer_bcd_static
 
 daemon_shared: $(RAZER_CHROMA_DAEMON_OBJ)
@@ -50,18 +50,18 @@ daemon_shared: $(RAZER_CHROMA_DAEMON_OBJ)
 	$(CC) -L../lib -rdynamic $(RAZER_CHROMA_DAEMON_OBJ) -lrazer_chroma $(LIBS) -o razer_bcd
 	@strip razer_bcd
 
-%.o: %.c 
+%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-%.do: %.c 
+%.do: %.c
 	$(CC) $(DEBUG_CFLAGS) -c -o $@ $<
 
 
-daemon_fx: 
+daemon_fx:
 	make -C fx all
 
-daemon_fx_clean: 
-	make -C fx clean 
+daemon_fx_clean:
+	make -C fx clean
 
 fedora_install:
 	install -v -D razer_bcd $(DESTDIR)/usr/sbin/razer_bcd
@@ -103,6 +103,5 @@ uninstall:
 clean: daemon_fx_clean
 	rm -f *.do *.da *.o razer_bcd razer_bcd_debug_shared razer_bcd_debug_static razer_bcd_static
 
-indent:	
+indent:
 	indent -bap -bli0 -i4 -l79 -ncs -npcs -npsl -fca -lc79 -fc1 -ts4 *.c *.h
-

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
 LIBS = -lm
-# -lSDL2 -lSDL2_image 
+# -lSDL2 -lSDL2_image
 MAJOR_VERSION = 0
 MINOR_VERSION = 3
 CSTD = -std=c99
@@ -13,7 +13,7 @@ CC=gcc
 LIBDBUS=$(shell pkg-config --libs dbus-1 > /dev/null 2>&1 && echo 0)
 
 ifeq ($(LIBDBUS), 0)
-	LIBS+= `pkg-config --libs dbus-1` 
+	LIBS+= `pkg-config --libs dbus-1`
 	CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 	DEBUG_CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 endif
@@ -21,7 +21,7 @@ endif
 
 all: examples_debug examples snake dynamic
 
-examples_debug: 
+examples_debug:
 	@echo "\n::\033[32m COMPILING examples [DEBUG]\033[0m"
 	@echo "=============================="
 	$(CC) example1.c $(DEBUG_CFLAGS) ../lib/librazer_chroma.da $(LIBS) -o example1_debug
@@ -31,7 +31,7 @@ examples_debug:
 	$(CC) dota_keys.c $(DEBUG_CFLAGS) ../lib/librazer_chroma.da $(LIBS) -o dota_keys_debug
 	$(CC) controller_example.c $(DEBUG_CFLAGS) ../lib/librazer_chroma_controller.da $(LIBS) -o controller_example_debug
 
-examples: 
+examples:
 	@echo "\n::\033[32m COMPILING examples\033[0m"
 	@echo "======================"
 	$(CC) example1.c $(CFLAGS) ../lib/librazer_chroma.a $(LIBS) -o example1
@@ -47,10 +47,10 @@ examples:
 	$(CC) controller_example.c $(CFLAGS) ../lib/librazer_chroma_controller.a $(LIBS) -o controller_example
 	@strip controller_example
 
-snake: 
+snake:
 	make -C snake_game all
 
-snake_clean: 
+snake_clean:
 	make -C snake_game clean
 
 dynamic:
@@ -63,5 +63,5 @@ dynamic:
 clean: snake_clean
 	rm -f *.do *.o input_example input_example_debug example1 example1_debug dota_keys dota_keys_debug dynamic input_map controller_example controller_example_debug input_map_debug raw_example raw_example_debug
 
-indent:	
+indent:
 	indent -bap -bli0 -i4 -l79 -ncs -npcs -npsl -fca -lc79 -fc1 -ts4 *.c *.h

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ LD=ld
 LIBDBUS=$(shell pkg-config --libs dbus-1 > /dev/null 2>&1 && echo 0)
 
 ifeq ($(LIBDBUS), 0)
-	LIBS+= `pkg-config --libs dbus-1` 
+	LIBS+= `pkg-config --libs dbus-1`
 	CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 	DEBUG_CFLAGS+= `pkg-config --cflags dbus-1` -DUSE_DBUS
 endif
@@ -72,10 +72,10 @@ endif
 razer_chroma_controller_shared_debug: $(RAZER_CHROMA_CONTROLLER_DEBUG_OBJ)
 	$(CC) -rdynamic -nostdlib -DCREATELIB -shared $(RAZER_CHROMA_CONTROLLER_DEBUG_OBJ) $(LDFLAGS) -o librazer_chroma_controller_debug.so
 
-%.o: %.c 
+%.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-%.do: %.c 
+%.do: %.c
 	$(CC) $(DEBUG_CFLAGS) -c -o $@ $<
 
 install:
@@ -97,16 +97,15 @@ endif
 uninstall:
 	@echo "\n::\033[32m REMOVING librazer_chroma.so\033[0m"
 	@echo "===================================="
-	@rm /usr/lib/librazer_chroma.so
+	@rm -f /usr/lib/librazer_chroma.so
 ifeq ($(LIBDBUS), 0)
 	@echo "\n::\033[32m REMOVING librazer_chroma_controller.so\033[0m"
 	@echo "===================================="
-	@rm /usr/lib/librazer_chroma_controller.so
+	@rm -f /usr/lib/librazer_chroma_controller.so
 endif
 
-clean: 
+clean:
 	rm -f *.do *.o *.a *.so *.da
 
-indent:	
+indent:
 	indent -bap -bli0 -i4 -l79 -ncs -npcs -npsl -fca -lc79 -fc1 -ts4 *.c *.h
-


### PR DESCRIPTION
Primarily, allow uninstall target to continue on soft errors.  For
example, we'll ignore errors when removing a file that doesn't exist.
In this way we get the most complete uninstall possible.

Additionally, as a minor change, remove unnecessary end-of-line whitespace.