### PR TITLE
Simplify keyboard layout name when using international variant

### DIFF
--- a/gui/lib/razer/keyboard.py
+++ b/gui/lib/razer/keyboard.py
@@ -358,4 +358,7 @@ def get_keyboard_layout():
         else:
             result = layout + '-' + variant
 
+    # If the user has an international layout variant ignore that part
+    result = result.replace('-altgr-intl', '')
+
     return result


### PR DESCRIPTION
Since the international layout variants are not different in the way the keys are distributed in the keyboard that part of the layout name can be left out for simplicity.

For more info [read this](https://zuttobenkyou.wordpress.com/2011/08/24/xorg-using-the-us-international-altgr-intl-variant-keyboard-layout/).

The problem this solves is one I had that made the GUI default to ``kb-gb`` when I tried to edit a profile.

The keyboard I have is en-US, but since my native language is Spanish and I wanted to type the "ñ" key and accents I set the en-US international variant. The GUI defaulted to the Great Britain layout because it couldn't recognize the added part to the layout name.