### PR TITLE
Fix missing apt-get requirement on ubuntu

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
                     <pre><code><span class="fa fa-dollar"></span> cd razer_chroma_drivers</code></pre>
 
                     <p>2. Install the packages needed to build the software.</p>
-                    <pre><code><span class="fa fa-dollar"></span> sudo apt-get install -y dpkg-dev libdbus-1-dev jq libsdl2-dev libsdl2-image-dev libfftw3-dev</code></pre>
+                    <pre><code><span class="fa fa-dollar"></span> sudo apt-get install -y dpkg-dev libdbus-1-dev jq libsdl2-dev libsdl2-image-dev libfftw3-dev libfftw3-3</code></pre>
 
                     <p>3. Build the software and driver.</p>
                     <pre><code><span class="fa fa-dollar"></span> make</code></pre>


### PR DESCRIPTION
Added `libfftw3-3` package after receiving this error:

```
Selecting previously unselected package razer-chroma-driver.
(Reading database ... 291440 files and directories currently installed.)
Preparing to unpack .../razer-chroma-driver_1.0.0_amd64.deb ...
Unpacking razer-chroma-driver (1.0.0) ...
dpkg: dependency problems prevent configuration of razer-chroma-driver:
 razer-chroma-driver depends on libfftw3-3 (>= 3.3.3-7ubuntu3); however:
  Package libfftw3-3 is not installed.

dpkg: error processing package razer-chroma-driver (--install):
 dependency problems - leaving unconfigured
```

Apparently `libfftw3-dev` was not enough.