### PR TITLE
Prevent Python module from quitting applications on failure.

### DIFF
--- a/pylib/daemon_dbus.py
+++ b/pylib/daemon_dbus.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import dbus
-import sys
-
 import razer.keyboard
 
 
@@ -45,8 +43,7 @@ class DaemonInterface(object):
             print('Successfully connected to dbus service.')
 
         except:
-            print("Failed to connect to the dbus service. Is the razer_bcd service running?")
-            sys.exit(1)
+            raise ValueError('Failed to connect to the dbus service. Is the razer_bcd service running?')
 
     def enumerate_devices(self):
         """


### PR DESCRIPTION
A small, quick fix to prevent the Python module from quitting applications (like [Polychromatic](https://github.com/lah7/polychromatic)) when there is an initialisation error. This allows the software to display a graphical error message.